### PR TITLE
解决部分IP的请求403问题

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,5 @@ dmypy.json
 test.py
 
 .idea
+harPool
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@
 
 ##### 方法列表
 - NewAuthenticator: 用户名密码登录,登录方法是普通的Web登录方式，无法获取长期有效的RefreshToken。使用函数选项模式（Functional options pattern）传递额外参数，包括代理、UserAgent、ChatOpenAiCookies、AuthOpenAiCookies.具体调用可以参考main.go中
-- Begin: 运行登录流程(登录完成后就可以通过其它方法获取信息)
-- GetPUID: 获取 puid
-- GetAuthResult: 获取AccessToken, puid, TeamUserId
+- Begin: 运行登录流程(登录完成后就可以通过其它方法获取信息)。 只获取 GetAuthResult.AccessToken字段
+- GetPUID: 获取 GetAuthResult.PUID字段。
+- GetTeamUserID: 获取 GetAuthResult.TeamUserID 字段.
+- GetAuthResult: 获取AccessToken, puid, TeamUserId。PUID只在开通了ChatGPT 4订阅权限下才会获取到。 TeamUserID也可能是在开通了Team后才会获取到
 - RenewWithCookies: 刷新AccessToken
 

--- a/README.md
+++ b/README.md
@@ -1,45 +1,14 @@
-# OpenAIAuth
-Fetch access tokens for chat.openai.com
+##### 基于github.com/xqdoo00o/OpenAIAuth, 添加Cookies可以解决部分的403问题
+- 有些特别黑的IP是无法靠请求中添加Cookies来解决的
+- 一般情况下 UserAgent、IP是和Cookies绑定的,其中一个变化会造成Cookies无效。
+- 有些黑的IP，下层的TCP链接断开后重新链接也会造成Cookies无效
+- 特别黑的IP，在正常浏览器中也无法过CloudFlare防护
 
-## Python version
-```py
-from OpenAIAuth import Auth0
-auth = Auth0(email_address="example@example.com", password="example_password")
-access_token = auth.get_access_token()
-```
 
-## Go version
-```go
-package main
+##### 方法列表
+- NewAuthenticator: 用户名密码登录,登录方法是普通的Web登录方式，无法获取长期有效的RefreshToken。使用函数选项模式（Functional options pattern）传递额外参数，包括代理、UserAgent、ChatOpenAiCookies、AuthOpenAiCookies.具体调用可以参考main.go中
+- Begin: 运行登录流程(登录完成后就可以通过其它方法获取信息)
+- GetPUID: 获取 puid
+- GetAuthResult: 获取AccessToken, puid, TeamUserId
+- RenewWithCookies: 刷新AccessToken
 
-import (
-	"fmt"
-	"os"
-
-	"github.com/xqdoo00o/OpenAIAuth/auth"
-)
-
-func main() {
-	auth := auth.NewAuthenticator(os.Getenv("OPENAI_EMAIL"), os.Getenv("OPENAI_PASSWORD"), os.Getenv("PROXY"))
-	err := auth.Begin()
-	if err.Error != nil {
-		println("Error: " + err.Details)
-		println("Location: " + err.Location)
-		println("Status code: " + fmt.Sprint(err.StatusCode))
-		return
-	}
-	token, err := auth.GetAccessToken()
-	if err.Error != nil {
-		println("Error: " + err.Details)
-		println("Location: " + err.Location)
-		println("Status code: " + fmt.Sprint(err.StatusCode))
-		return
-	}
-	fmt.Println(token)
-}
-```
-
-## Credits
-- @linweiyuan
-- @rawandahmad698
-- @pengzhile

--- a/README.md
+++ b/README.md
@@ -13,3 +13,7 @@
 - GetAuthResult: 获取AccessToken, puid, TeamUserId。PUID只在开通了ChatGPT 4订阅权限下才会获取到。 TeamUserID也可能是在开通了Team后才会获取到
 - RenewWithCookies: 刷新AccessToken
 
+
+##### 其它改进
+- 在某些请求中加上sec-ch-ua-arch和sec-ch-ua-bitness能过避免让接口返回403
+

--- a/README.md
+++ b/README.md
@@ -4,16 +4,20 @@
 - 有些黑的IP，下层的TCP链接断开后重新链接也会造成Cookies无效
 - 特别黑的IP，在正常浏览器中也无法过CloudFlare防护
 
-
 ##### 方法列表
-- NewAuthenticator: 用户名密码登录,登录方法是普通的Web登录方式，无法获取长期有效的RefreshToken。使用函数选项模式（Functional options pattern）传递额外参数，包括代理、UserAgent、ChatOpenAiCookies、AuthOpenAiCookies.具体调用可以参考main.go中
+- NewAuthenticator: 用户名密码登录,登录方法是普通的Web登录方式，无法获取长期有效的RefreshToken。使用函数选项模式（Functional options pattern）传递额外参数，包括代理、UserAgent、ChatOpenAiCookies、AuthOpenAiCookies、Auth0OpenAiCookies.具体调用可以参考main.go中
 - Begin: 运行登录流程(登录完成后就可以通过其它方法获取信息)。 只获取 GetAuthResult.AccessToken字段
 - GetPUID: 获取 GetAuthResult.PUID字段。
 - GetTeamUserID: 获取 GetAuthResult.TeamUserID 字段.
 - GetAuthResult: 获取AccessToken, puid, TeamUserId。PUID只在开通了ChatGPT 4订阅权限下才会获取到。 TeamUserID也可能是在开通了Team后才会获取到
 - RenewWithCookies: 刷新AccessToken
 
+##### 如何获取登录har
+- 获取的har是登录的har文件，不是聊天的har。流程可以参考聊天har的获取方式[参考这里](https://github.com/gngpp/ninja/wiki/2-Arkose)
+- 走登录流程，要保存har文件的链接是```https://tcr9i.openai.com/fc/gt2/public_key/0A1D34FC-659D-4E23-B17B-694DCFCF6A6C```
+- har包含浏览器指纹，多次使用后可能会跟IP一样出现不能使用的问题，不能使用后需要更换。或者多放几个不同浏览器或者不同浏览器版本的har进去
 
-##### 其它改进
-- 在某些请求中加上sec-ch-ua-arch和sec-ch-ua-bitness能过避免让接口返回403
-
+##### 如何获取过CloudFlare盾的cookie
+- 可以联系我们解决
+- 或者自己复制自己过了CloudFlare盾后的Cookie
+- 或者自己编写过盾程序,但目前puppeteer、playwright都能被检测到，不管是否是开启了UI界面

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-##### 基于github.com/xqdoo00o/OpenAIAuth, 添加Cookies可以解决部分的403问题
+##### 基于github.com/xqdoo00o/OpenAIAuth, 添加Cookies可以解决部分的403问题,只更新了go代码部分
 - 有些特别黑的IP是无法靠请求中添加Cookies来解决的
 - 一般情况下 UserAgent、IP是和Cookies绑定的,其中一个变化会造成Cookies无效。
 - 有些黑的IP，下层的TCP链接断开后重新链接也会造成Cookies无效

--- a/auth/OpenAiAuth.go
+++ b/auth/OpenAiAuth.go
@@ -306,9 +306,9 @@ func (userLogin *UserLogin) GetAccessTokenInternal(code string) (string, int, er
 }
 
 func (userLogin *UserLogin) Begin() *Error {
-	_, err, token := userLogin.GetToken()
+	statusCode, err, token := userLogin.GetToken()
 	if err != "" {
-		return NewError("begin", 0, err)
+		return NewError("begin", statusCode, err)
 	}
 	userLogin.Result.AccessToken = token
 	return nil
@@ -425,6 +425,7 @@ func (userLogin *UserLogin) GetTeamUserID() (string, *Error) {
 	if resp.StatusCode != 200 {
 		return "", NewError("get_teamuserid", resp.StatusCode, "Failed to make request")
 	}
+
 	var userId UserID
 	err = json.NewDecoder(resp.Body).Decode(&userId)
 	if err != nil {

--- a/auth/OpenAiAuth.go
+++ b/auth/OpenAiAuth.go
@@ -67,10 +67,13 @@ const (
 )
 
 type UserLogin struct {
-	Username string
-	Password string
-	client   tls_client.HttpClient
-	Result   Result
+	Username          string
+	Password          string
+	client            tls_client.HttpClient
+	Result            Result
+	userAgent         string
+	chatOpenAiCookies map[string]string // chat.openai.com 需要的Cookies
+	authOpenAiCookies map[string]string // auth.openai.com 需要的Cookies
 }
 
 //goland:noinspection GoUnhandledErrorResult,SpellCheckingInspection
@@ -93,12 +96,20 @@ func getHttpClient() tls_client.HttpClient {
 	return client
 }
 
-func NewAuthenticator(emailAddress, password, proxy string) *UserLogin {
+func NewAuthenticator(emailAddress, password string, opts ...Option) *UserLogin {
 	userLogin := &UserLogin{
-		Username: emailAddress,
-		Password: password,
-		client:   NewHttpClient(proxy),
+		Username:          emailAddress,
+		Password:          password,
+		client:            NewHttpClient(""),
+		userAgent:         UserAgent,
+		chatOpenAiCookies: map[string]string{},
+		authOpenAiCookies: map[string]string{},
 	}
+
+	for _, opt := range opts {
+		opt(userLogin)
+	}
+
 	return userLogin
 }
 

--- a/auth/options.go
+++ b/auth/options.go
@@ -25,3 +25,9 @@ func WithAuthOpenaiCookies(authOpenAiCookies map[string]string) Option {
 		ul.authOpenAiCookies = authOpenAiCookies
 	}
 }
+
+func WithAuth0OpenaiCookies(auth0OpenAiCookies map[string]string) Option {
+	return func(ul *UserLogin) {
+		ul.auth0OpenAiCookies = auth0OpenAiCookies
+	}
+}

--- a/auth/options.go
+++ b/auth/options.go
@@ -1,5 +1,7 @@
 package auth
 
+import "strings"
+
 type Option func(*UserLogin)
 
 func WithProxy(proxyUrl string) Option {
@@ -16,18 +18,38 @@ func WithUserAgent(userAgent string) Option {
 
 func WithChatOpenAiCookies(chatOpenAiCookies map[string]string) Option {
 	return func(ul *UserLogin) {
-		ul.chatOpenAiCookies = chatOpenAiCookies
+
+		cookiePairs := []string{}
+		for k, v := range chatOpenAiCookies {
+			cookiePairs = append(cookiePairs, k+"="+v)
+		}
+		cookieStr := strings.Join(cookiePairs, ";")
+
+		ul.chatOpenAiCookies = cookieStr
 	}
 }
 
 func WithAuthOpenaiCookies(authOpenAiCookies map[string]string) Option {
 	return func(ul *UserLogin) {
-		ul.authOpenAiCookies = authOpenAiCookies
+		cookiePairs := []string{}
+		for k, v := range authOpenAiCookies {
+			cookiePairs = append(cookiePairs, k+"="+v)
+		}
+		cookieStr := strings.Join(cookiePairs, ";")
+
+		ul.authOpenAiCookies = cookieStr
 	}
 }
 
 func WithAuth0OpenaiCookies(auth0OpenAiCookies map[string]string) Option {
 	return func(ul *UserLogin) {
-		ul.auth0OpenAiCookies = auth0OpenAiCookies
+
+		cookiePairs := []string{}
+		for k, v := range auth0OpenAiCookies {
+			cookiePairs = append(cookiePairs, k+"="+v)
+		}
+		cookieStr := strings.Join(cookiePairs, ";")
+
+		ul.auth0OpenAiCookies = cookieStr
 	}
 }

--- a/auth/options.go
+++ b/auth/options.go
@@ -1,0 +1,27 @@
+package auth
+
+type Option func(*UserLogin)
+
+func WithProxy(proxyUrl string) Option {
+	return func(ul *UserLogin) {
+		ul.client = NewHttpClient(proxyUrl)
+	}
+}
+
+func WithUserAgent(userAgent string) Option {
+	return func(ul *UserLogin) {
+		ul.userAgent = userAgent
+	}
+}
+
+func WithChatOpenAiCookies(chatOpenAiCookies map[string]string) Option {
+	return func(ul *UserLogin) {
+		ul.chatOpenAiCookies = chatOpenAiCookies
+	}
+}
+
+func WithAuthOpenaiCookies(authOpenAiCookies map[string]string) Option {
+	return func(ul *UserLogin) {
+		ul.authOpenAiCookies = authOpenAiCookies
+	}
+}

--- a/main.go
+++ b/main.go
@@ -9,13 +9,12 @@ import (
 )
 
 func main() {
-	proxyOption := auth.WithProxy(os.Getenv("PROXY"))
-	userAgentOption := auth.WithUserAgent(os.Getenv("USER_AGENT"))
-	chatOpenAiCookies := auth.WithChatOpenAiCookies(map[string]string{})
-	authOpenAICookies := auth.WithAuthOpenaiCookies(map[string]string{})
+	proxyOption := auth.WithProxy("http://localhost:7890")
+	// userAgentOption := auth.WithUserAgent(os.Getenv("USER_AGENT"))
+	// chatOpenAiCookies := auth.WithChatOpenAiCookies(map[string]string{})
+	// authOpenAICookies := auth.WithAuthOpenaiCookies(map[string]string{})
 
-	auth := auth.NewAuthenticator(os.Getenv("OPENAI_EMAIL"), os.Getenv("OPENAI_PASSWORD"),
-		proxyOption, userAgentOption, chatOpenAiCookies, authOpenAICookies)
+	auth := auth.NewAuthenticator(os.Getenv("OPENAI_EMAIL"), os.Getenv("OPENAI_PASSWORD"), proxyOption)
 	err := auth.Begin()
 	if err != nil {
 		println("Error: " + err.Details)
@@ -23,7 +22,7 @@ func main() {
 		println("Status code: " + fmt.Sprint(err.StatusCode))
 		return
 	}
-	// if os.Getenv("PROXY") != "" {
+
 	_, err = auth.GetPUID()
 	if err != nil {
 		println("Error: " + err.Details)
@@ -31,7 +30,15 @@ func main() {
 		println("Status code: " + fmt.Sprint(err.StatusCode))
 		return
 	}
+
+	// _, err = auth.GetTeamUserID()
+	// if err != nil {
+	// 	println("Error: " + err.Details)
+	// 	println("Location: " + err.Location)
+	// 	println("Status code: " + fmt.Sprint(err.StatusCode))
+	// 	return
 	// }
+
 	// JSON encode auth.GetAuthResult()
 	result := auth.GetAuthResult()
 	result_json, _ := json.Marshal(result)

--- a/main.go
+++ b/main.go
@@ -9,12 +9,19 @@ import (
 )
 
 func main() {
-	proxyOption := auth.WithProxy("http://localhost:7890")
+	// Option都是可选的，不传递参数为不应用这个参数
+	proxyOption := auth.WithProxy(os.Getenv("PROXY"))
 	userAgentOption := auth.WithUserAgent("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36")
-	// chatOpenAiCookies := auth.WithChatOpenAiCookies(map[string]string{})
-	// authOpenAICookies := auth.WithAuthOpenaiCookies(map[string]string{})
+	auth0OpenAiCookiesOption := auth.WithAuth0OpenaiCookies(map[string]string{
+		// 这里使用你的Cookies替换,Cookies跟IP、UserAgent绑定
+		// "__cf_bm":      "xxxx",
+		// "cf_clearance": "yyyy",
+	})
+	// chatOpenAiCookiesOption := auth.WithChatOpenAiCookies(map[string]string{})
+	// authOpenAICookiesOption := auth.WithAuthOpenaiCookies(map[string]string{})
 
-	auth := auth.NewAuthenticator(os.Getenv("OPENAI_EMAIL"), os.Getenv("OPENAI_PASSWORD"), proxyOption, userAgentOption)
+	auth := auth.NewAuthenticator(os.Getenv("OPENAI_EMAIL"), os.Getenv("OPENAI_PASSWORD"),
+		proxyOption, userAgentOption, auth0OpenAiCookiesOption)
 	err := auth.Begin()
 	if err != nil {
 		println("Error: " + err.Details)

--- a/main.go
+++ b/main.go
@@ -23,13 +23,13 @@ func main() {
 		return
 	}
 
-	_, err = auth.GetPUID()
-	if err != nil {
-		println("Error: " + err.Details)
-		println("Location: " + err.Location)
-		println("Status code: " + fmt.Sprint(err.StatusCode))
-		return
-	}
+	// _, err = auth.GetPUID()
+	// if err != nil {
+	// 	println("Error: " + err.Details)
+	// 	println("Location: " + err.Location)
+	// 	println("Status code: " + fmt.Sprint(err.StatusCode))
+	// 	return
+	// }
 
 	// _, err = auth.GetTeamUserID()
 	// if err != nil {

--- a/main.go
+++ b/main.go
@@ -9,7 +9,13 @@ import (
 )
 
 func main() {
-	auth := auth.NewAuthenticator(os.Getenv("OPENAI_EMAIL"), os.Getenv("OPENAI_PASSWORD"), os.Getenv("PROXY"))
+	proxyOption := auth.WithProxy(os.Getenv("PROXY"))
+	userAgentOption := auth.WithUserAgent(os.Getenv("USER_AGENT"))
+	chatOpenAiCookies := auth.WithChatOpenAiCookies(map[string]string{})
+	authOpenAICookies := auth.WithAuthOpenaiCookies(map[string]string{})
+
+	auth := auth.NewAuthenticator(os.Getenv("OPENAI_EMAIL"), os.Getenv("OPENAI_PASSWORD"),
+		proxyOption, userAgentOption, chatOpenAiCookies, authOpenAICookies)
 	err := auth.Begin()
 	if err != nil {
 		println("Error: " + err.Details)

--- a/main.go
+++ b/main.go
@@ -10,11 +10,11 @@ import (
 
 func main() {
 	proxyOption := auth.WithProxy("http://localhost:7890")
-	// userAgentOption := auth.WithUserAgent(os.Getenv("USER_AGENT"))
+	userAgentOption := auth.WithUserAgent("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36")
 	// chatOpenAiCookies := auth.WithChatOpenAiCookies(map[string]string{})
 	// authOpenAICookies := auth.WithAuthOpenaiCookies(map[string]string{})
 
-	auth := auth.NewAuthenticator(os.Getenv("OPENAI_EMAIL"), os.Getenv("OPENAI_PASSWORD"), proxyOption)
+	auth := auth.NewAuthenticator(os.Getenv("OPENAI_EMAIL"), os.Getenv("OPENAI_PASSWORD"), proxyOption, userAgentOption)
 	err := auth.Begin()
 	if err != nil {
 		println("Error: " + err.Details)


### PR DESCRIPTION
- 没有黑透的IP可以解决，黑透的暂时无法解决
- 通过设置Cookies、UserAgent、代理IP来绕过CloudFlare的防护
- 增加了一些返回403的判断